### PR TITLE
Add cli_parse example to Class7 collateral

### DIFF
--- a/class7/collateral/textfsm/textfsm2.yml
+++ b/class7/collateral/textfsm/textfsm2.yml
@@ -17,6 +17,7 @@
     - ansible.builtin.set_fact:
         show_ip: "{{ output.stdout[0] }}"
 
+    # see textfsm4.yml for 'cli_parse' example
     # Only abbreviated name works: needs migrated to 'cli_parse'
     - name: TextFSM test
       textfsm_parser:

--- a/class7/collateral/textfsm/textfsm4.yml
+++ b/class7/collateral/textfsm/textfsm4.yml
@@ -1,0 +1,19 @@
+---
+- name: TextFSM Example4
+  hosts: cisco5
+  gather_facts: False
+  vars:
+    fsm_template: "cisco_ios_show_ip_interface_brief.template"
+
+  tasks:
+    # no need to fetch raw output as 'cli_parse' does this inherently
+    - name: cli_parse TextFSM test
+      ansible.utils.cli_parse:
+        command: show ip interface brief
+        parser:
+          name: ansible.utils.textfsm
+          os: cisco_ios
+        set_fact: show_ip_parsed
+
+    - ansible.builtin.debug:
+        var: show_ip_parsed


### PR DESCRIPTION
Add `ansible.utils.cli_parse` usage example to Class7 collateral
Add a note to textfsm2.yml referring to textfsm4.yml for a cli_parse example